### PR TITLE
Fixed PHP Fatal error.

### DIFF
--- a/e_cron.php
+++ b/e_cron.php
@@ -138,7 +138,7 @@ class calendar_menu_cron // include plugin-folder in the name.
 
 
 		$this->startTime = mktime(0, 0, 0, date('n'), date('d'), date('Y'));	// Date for start processing
-		setScVar('event_calendar_shortcodes', 'ecalClass', &$this->ecalClass);			// Give shortcode a pointer to calendar class
+		setScVar('event_calendar_shortcodes', 'ecalClass', $this->ecalClass);			// Give shortcode a pointer to calendar class
 
 
 		$this->logRequirement = varset($this->ecal_class->pref['eventpost_emaillog'], 0);


### PR DESCRIPTION
Fatal error: Call-time pass-by-reference has been removed in ... /e107_plugins/calendar_menu/e_cron.php on line 141
